### PR TITLE
Added the new relationships-emotions page into the user flow

### DIFF
--- a/app/views/brain-development/brain-parts.html
+++ b/app/views/brain-development/brain-parts.html
@@ -32,26 +32,26 @@ Early Years Foundation
     <main class="govuk-main-wrapper">
 
       <div class="govuk-grid-row">
-        
+
             <div class="govuk-grid-column-one-quarter">
 
 
             </div>
 
-          
+
 
         <div class="govuk-grid-column-two-thirds">
-          <span class="govuk-caption-l">Topic 4 of 11</span>
+          <span class="govuk-caption-l">Page 4 of 10</span>
           <h1 class="govuk-heading-l">
             Parts of the brain
           </h1>
-    
 
-            <img src="/public/images/home/brain-diagram.jpg" width="200" height="300" alt="">
+
+            <img src="/public/images/home/brain-diagram.jpg"  alt="Parts of the brain">
         </br>
     </br>
 
-         
+
 <h3 class="govuk-heading-s">Brain stem</h3/>
 
           <p class="govuk-body">The brain stem at the top of your spinal cord where your head joins your neck. This is the most developed section of your brain at birth. This vital part of the brain controls your breathing, heart rate and blood pressure.</p>
@@ -89,7 +89,7 @@ Early Years Foundation
 <p class="govuk-body">It’s essential that a child is exposed to a wide variety of visual, auditory and practical tasks that enable them to test concepts and build memory skills.</p>
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
-         
+
             <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="topic-intro">Previous</a>
             <a class="govuk-button align-right" data-module="govuk-button" href="quiz-1">Next</a>
 

--- a/app/views/brain-development/development-birth-two.html
+++ b/app/views/brain-development/development-birth-two.html
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                
+
 
             </div>
 
@@ -45,11 +45,11 @@ Early Years Foundation
         </div>
 
         <div class="govuk-grid-column-two-thirds">
-          <span class="govuk-caption-l">Topic 6 of 11</span>
+          <span class="govuk-caption-l">Page 6 of 10</span>
           <h1 class="govuk-heading-l">
             Brain development from 0 to 2 years old
           </h1>
-    
+
 
   <p class="govuk-body">The most significant growth for a child’s brain happens between birth and 2 years of age. A 2 year old’s brain is three quarters of its adult size.</p>
 <p class="govuk-body">The early years are the period where more and more connections develop in the brain, resulting in the child being able to carry out more complex tasks. They are therefore a crucial period of opportunity for the child’s development to be shaped by experience, environment and opportunity.
@@ -57,7 +57,7 @@ Early Years Foundation
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
 
-      
+
               <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="quiz-1">Previous</a>
               <a class="govuk-button align-right" data-module="govuk-button" href="piaget-sensorimotor.html">Next</a>
 

--- a/app/views/brain-development/module-intro.html
+++ b/app/views/brain-development/module-intro.html
@@ -32,9 +32,9 @@ Early Years Foundation
     <main class="govuk-main-wrapper">
 
       <div class="govuk-grid-row">
-       
+
         <div class="govuk-grid-column-two-thirds">
-          <span class="govuk-caption-l">Topic 1 of 11</span>
+          <span class="govuk-caption-l">Page 1 of 10</span>
           <h1 class="govuk-heading-l">
             Brain development in the early years
           </h1>
@@ -56,7 +56,7 @@ Brain development is a long process. The brain starts to develop around 2 weeks 
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
 
-          
+
             <a class="govuk-button align-right" data-module="govuk-button" href="submodule-intro">Next</a>
 
 

--- a/app/views/brain-development/piaget-current-research.html
+++ b/app/views/brain-development/piaget-current-research.html
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-               
+
             </div>
 
           </div>
@@ -50,7 +50,7 @@ Early Years Foundation
             Recent updates to Piaget's theories
           </h1>
 
-     
+
 
           <p class="govuk-body">Large numbers of studies and experiments were carried out to support Piaget’s work and positively reinforced his findings.</p>
 
@@ -68,7 +68,7 @@ Early Years Foundation
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
 
             <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="piaget-sensorimotor">Previous</a>
-            <a class="govuk-button align-right" data-module="govuk-button" href="quiz-2">Next</a>
+            <a class="govuk-button align-right" data-module="govuk-button" href="relationships-emotions">Next</a>
 
         </div>
       </div>

--- a/app/views/brain-development/piaget-current-research.html
+++ b/app/views/brain-development/piaget-current-research.html
@@ -45,7 +45,7 @@ Early Years Foundation
 
         <div class="govuk-grid-column-two-thirds">
 
-          <span class="govuk-caption-l">Topic 8 of 11</span>
+          <span class="govuk-caption-l">Page 8 of 10</span>
           <h1 class="govuk-heading-l">
             Recent updates to Piaget's theories
           </h1>

--- a/app/views/brain-development/piaget-sensorimotor.html
+++ b/app/views/brain-development/piaget-sensorimotor.html
@@ -46,7 +46,7 @@ Early Years Foundation
 
         <div class="govuk-grid-column-two-thirds">
 
-          <span class="govuk-caption-l">Topic 7 of 11</span>
+          <span class="govuk-caption-l">Page 7 of 10</span>
           <h1 class="govuk-heading-l">
             Jean Piaget and the sensorimotor stage
           </h1>

--- a/app/views/brain-development/quiz-1-right.html
+++ b/app/views/brain-development/quiz-1-right.html
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                
+
 
 
             </div>
@@ -48,7 +48,7 @@ Early Years Foundation
         <div class="govuk-grid-column-two-thirds">
 
 
-          <span class="govuk-caption-l">Topic 5 of 11</span>
+          <span class="govuk-caption-l">Page 5 of 10</span>
           <h1 class="govuk-heading-l">
             Check your learning
           </h1>
@@ -107,7 +107,7 @@ Early Years Foundation
                       </div>
                     </div>
 
-          
+
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
 

--- a/app/views/brain-development/quiz-1-wrong.html
+++ b/app/views/brain-development/quiz-1-wrong.html
@@ -47,7 +47,7 @@ Early Years Foundation
 
         <div class="govuk-grid-column-two-thirds">
 
-          <span class="govuk-caption-l">Topic 5 of 13</span>
+          <span class="govuk-caption-l">Page 5 of 10</span>
           <h1 class="govuk-heading-l">
             Check your learning
           </h1>
@@ -107,7 +107,7 @@ Early Years Foundation
                     </div>
 
 
-        
+
 
 
 

--- a/app/views/brain-development/quiz-1.html
+++ b/app/views/brain-development/quiz-1.html
@@ -44,16 +44,16 @@ Early Years Foundation
         </div>
 
         <div class="govuk-grid-column-two-thirds">
-          <span class="govuk-caption-l">Topic 5 of 11</span>
+          <span class="govuk-caption-l">Page 5 of 10</span>
           <h1 class="govuk-heading-l">
             Check your learning
           </h1>
-    
+
 
 
         <div class="govuk-form-group">
             <form class="form" action="../quiz-1-answer" method="post">
-              
+
               {{ govukRadios({
                 idPrefix: "part-of-brain",
                 name: "part-of-brain",
@@ -87,7 +87,7 @@ Early Years Foundation
 
               <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="brain-parts">Previous</a>
               <a class="govuk-button align-right" data-module="govuk-button" href="quiz-1-right">Next </a>
-         
+
 
             </form>
           </div>

--- a/app/views/brain-development/quiz-2-right.html
+++ b/app/views/brain-development/quiz-2-right.html
@@ -46,12 +46,12 @@ Early Years Foundation
 
         <div class="govuk-grid-column-two-thirds">
 
-          <span class="govuk-caption-l">Topic 9 of 29</span>
+          <span class="govuk-caption-l">Page 5 of 10</span>
           <h1 class="govuk-heading-l">
             Check your understanding
           </h1>
 
-         
+
 
           <div class="govuk-form-group">
               <fieldset class="govuk-fieldset">
@@ -104,7 +104,7 @@ Early Years Foundation
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
 
-    
+
               <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="quiz-2">Previous</a>
               <a class="govuk-button align-right" data-module="govuk-button" href="test-1-q1">Next</a>
         </div>

--- a/app/views/brain-development/recap.html
+++ b/app/views/brain-development/recap.html
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-          
+
 
             </div>
 
@@ -70,6 +70,7 @@ Early Years Foundation
 
             <li>babies and children need stimulation in order to help their brains develop  </li>
             <li>the stage of brain development between birth and 2 is called the sensorimotor stage </li>
+            <li>nurturing a secure relationship with children can play an influential role in shaping children’s behaviour which will support successful learning and development</li>
           </ul>
 
           <h3 class="govuk-heading-s">Put what you’ve learned into practice</h3>
@@ -83,6 +84,8 @@ Early Years Foundation
 
           <h3 class="govuk-heading-s">Further reading</h3>
 
+          <p class="govuk-body">You can read more about <a href="https://help-for-early-years-providers.education.gov.uk/personal-social-and-emotional-development">personal, social and emotional development in the EYFS</a> on the Department for Education's Help for early years providers website. </p>
+
           <p class="govuk-body">You can read more about <a href="https://developingchild.harvard.edu/resources/inbrief-science-of-ecd/">the science of early childhood development</a> on the Harvard University website. </p>
 
           <p class="govuk-body">You can read more about how <a href="https://learning.nspcc.org.uk/child-health-development/childhood-trauma-brain-development">childhood trauma affects brain development</a> on the NSPCC website. </p>
@@ -91,7 +94,7 @@ Early Years Foundation
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
 
-              <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="quiz-2">Previous</a>
+              <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="relationships-emotions">Previous</a>
               <a class="govuk-button align-right" data-module="govuk-button" href="test-intro">Next</a>
 
 

--- a/app/views/brain-development/recap.html
+++ b/app/views/brain-development/recap.html
@@ -47,7 +47,7 @@ Early Years Foundation
         <div class="govuk-grid-column-two-thirds">
 
 
-          <span class="govuk-caption-l">Topic 11 of 11</span>
+          <span class="govuk-caption-l">Page 10 of 10</span>
           <h1 class="govuk-heading-l">
             Recap and further reading
           </h1>

--- a/app/views/brain-development/relationships-emotions.html
+++ b/app/views/brain-development/relationships-emotions.html
@@ -46,7 +46,7 @@ Early Years Foundation
 
         <div class="govuk-grid-column-two-thirds">
 
-          <span class="govuk-caption-l">Page 9 of 11</span>
+          <span class="govuk-caption-l">Page 9 of 10</span>
           <h1 class="govuk-heading-l">
             The importance of secure relationships and understanding emotions
           </h1>

--- a/app/views/brain-development/relationships-emotions.html
+++ b/app/views/brain-development/relationships-emotions.html
@@ -46,7 +46,7 @@ Early Years Foundation
 
         <div class="govuk-grid-column-two-thirds">
 
-          <span class="govuk-caption-l">Page 54 of 68</span>
+          <span class="govuk-caption-l">Page 9 of 11</span>
           <h1 class="govuk-heading-l">
             The importance of secure relationships and understanding emotions
           </h1>

--- a/app/views/brain-development/submodule-intro.html
+++ b/app/views/brain-development/submodule-intro.html
@@ -31,8 +31,8 @@ Early Years Foundation
     <div class="govuk-grid-row">
 
       <div class="govuk-grid-column-two-thirds">
-   
-        <span class="govuk-caption-l">Topic 2 of 11</span>
+
+        <span class="govuk-caption-l">Page 2 of 10</span>
         <h1 class="govuk-heading-l">
           The developing brain
         </h1>

--- a/app/views/brain-development/test-1-fail.html
+++ b/app/views/brain-development/test-1-fail.html
@@ -19,7 +19,7 @@ Early Years Foundation
     <ol class="govuk-breadcrumbs__list">
 
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#">Supporting physical development in the early years overview</a>
+        <a class="govuk-breadcrumbs__link" href="#">Brain development in the early years</a>
       </li>
 
     </ol>
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-   
+
             </div>
 
           </div>
@@ -57,13 +57,13 @@ Early Years Foundation
             </div>
             <div class="govuk-notification-banner__content">
               <p class="govuk-notification-banner__heading">
-                You scored 33%. 
+                You scored 33%.
                 <p>Unfortunately you have not scored  highly enough to receive a certificate of achievement for this module.  </p>
                 <p>You can see the questions you answered incorrectly.  </p>
                 <p>You may wish to revisit some of the learning before taking the test again.   </p>
               </p>
             </div>
-            
+
           </div>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -73,7 +73,7 @@ Early Years Foundation
             </legend>
             <div class="govuk-radios" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="where-do-you-live" name="where-do-you-live" type="radio" value="england">
+                <input class="govuk-radios__input" id="where-do-you-live" name="where-do-you-live" type="radio" value="england" checked>
                 <label class="govuk-label govuk-radios__label" for="where-do-you-live">
                  True
                 </label>
@@ -86,13 +86,13 @@ Early Years Foundation
               </div>
           </fieldset>
           <div class="govuk-inset-text">
-           <p>You answered true. That's not quite right</p> 
-           <p>Sarah giggling when she sees the teddy bear suggests that she is surprised that it is still there. 
+           <p>You answered true. That's not quite right</p>
+           <p>Sarah giggling when she sees the teddy bear suggests that she is surprised that it is still there.
                A child who has an understanding of object permanence would not be surprised to see the bear, as they
-                would know that it was there all along. </p> 
-                <p class="govuk-body">You may want to revisit the topic: <a class="govuk-link" href=" ">Jean Piaget</a> and the <a class="govuk-link" href=" ">sensorimotor </a> stage.</p>
+                would know that it was there all along. </p>
+                <p class="govuk-body">You may want to revisit the topic: <a class="govuk-link" href="#">Jean Piaget and the sensorimotor</a> stage.</p>
           </div>
-          
+
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h2 class="govuk-heading-m">
@@ -103,36 +103,48 @@ Early Years Foundation
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="where-do-you-live" name="where-do-you-live" type="radio" value="england">
                 <label class="govuk-label govuk-radios__label" for="where-do-you-live">
-                 True
+                  3 to 4 months
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="where-do-you-live-2" name="where-do-you-live" type="radio" value="scotland">
+                <input class="govuk-radios__input" id="where-do-you-live-2" name="where-do-you-live" type="radio" value="scotland" checked>
                 <label class="govuk-label govuk-radios__label" for="where-do-you-live-2">
-                  False
+                  6 to 7 months
                 </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="where-do-you-live-2" name="where-do-you-live" type="radio" value="scotland">
+                  <label class="govuk-label govuk-radios__label" for="where-do-you-live-2">
+                    9 to 10 months
+                  </label>
+                  </div>
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="where-do-you-live-2" name="where-do-you-live" type="radio" value="scotland">
+                    <label class="govuk-label govuk-radios__label" for="where-do-you-live-2">
+                      1 year
+                    </label>
               </div>
           </fieldset>
           <div class="govuk-inset-text">
-           <p>You answered 7 to 8 months. That's not quite right</p> 
-           <p>In your setting, you can assess a child’s understanding of object permanence by their reaction when you hide a 
-               favourite toy. If the child appears confused or upset and doesn't look for the toy, then they haven't yet grasped the concept. </p> 
-                <p class="govuk-body">You may want to revisit the topic: <a class="govuk-link" href=" ">Jean Piaget</a> and the <a class="govuk-link" href=" ">sensorimotor </a> stage.</p>
+           <p>You answered 6 to 7 months. That's not quite right</p>
+           <p>In your setting, you can assess a child’s understanding of object permanence by their reaction when you hide a
+               favourite toy. If the child appears confused or upset and doesn't look for the toy, then they haven't yet grasped the concept. </p>
+                <p class="govuk-body">You may want to revisit the topic: <a class="govuk-link" href="#">Jean Piaget and the sensorimotor</a> stage.</p>
           </div>
-          
+
                 </div>
 
 
             </fieldset>
           </div>
 
-       
+
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
 
             <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="test-1-pass">Previous</a>
             <a class="govuk-button align-right" data-module="govuk-button" href="my-learning-fail">Finish</a>
-  
+
 
 
         </div>

--- a/app/views/brain-development/test-1-q1-right.html
+++ b/app/views/brain-development/test-1-q1-right.html
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-         
+
             </div>
 
           </div>
@@ -51,7 +51,7 @@ Early Years Foundation
           </h1>
 
 
-          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peeakaboo </p>
+          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peekaboo </p>
 
           <p class="govuk-body">Childminder Chris is playing with 6 month old Sarah. Chris is covering a teddy with a blanket. When the teddy is covered, Sarah immediately pulls off the blanket to find it and giggles.
  </p>
@@ -108,7 +108,7 @@ Early Years Foundation
             <a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="recap">Previous</a>
             <a class="govuk-button align-right" data-module="govuk-button" href="test-1-q2">Next</a>
 
-  
+
 
 
 

--- a/app/views/brain-development/test-1-q1-wrong.html
+++ b/app/views/brain-development/test-1-q1-wrong.html
@@ -175,7 +175,7 @@ Early Years Foundation
           <h1 class="govuk-heading-l">End of module test</h1>
 
 
-          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peeakaboo </p>
+          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peekaboo </p>
 
           <p class="govuk-body">Childminder Chris is playing with 6 month old Sarah. Chris is covering a teddy with a blanket. When the teddy is covered, Sarah immediately pulls off the blanket to find it and giggles.
  </p>

--- a/app/views/brain-development/test-1-q1.html
+++ b/app/views/brain-development/test-1-q1.html
@@ -54,7 +54,7 @@ Early Years Foundation
 
 
 
-          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peeakaboo </p>
+          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peekaboo </p>
 
           <p class="govuk-body">Childminder Chris is playing with 6 month old Sarah. Chris is covering a teddy with a blanket. When the teddy is covered, Sarah immediately pulls off the blanket to find it and giggles.
  </p>

--- a/app/views/brain-development/test-1-q2.html
+++ b/app/views/brain-development/test-1-q2.html
@@ -19,7 +19,7 @@ Early Years Foundation
     <ol class="govuk-breadcrumbs__list">
 
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#">Supporting physical development in the early years overview</a>
+        <a class="govuk-breadcrumbs__link" href="#">Brain development in the early years</a>
       </li>
 
     </ol>
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-     
+
 
 
             </div>
@@ -47,14 +47,14 @@ Early Years Foundation
 
         <div class="govuk-grid-column-two-thirds">
 
-    
+
           <span class="govuk-caption-l">Question  2 of 3</span>
           <h1 class="govuk-heading-l">
             End of module test
           </h1>
 
 
-          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peeakaboo </p>
+          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peekaboo </p>
 
           <p class="govuk-body">Childminder Chris is playing with 6 month old Sarah. Chris is covering a teddy with a blanket. When the teddy is covered, Sarah immediately pulls off the blanket to find it and giggles.
  </p>

--- a/app/views/brain-development/test-1-q3.html
+++ b/app/views/brain-development/test-1-q3.html
@@ -19,7 +19,7 @@ Early Years Foundation
     <ol class="govuk-breadcrumbs__list">
 
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#">Supporting physical development in the early years overview</a>
+        <a class="govuk-breadcrumbs__link" href="#">Brain development in the early years</a>
       </li>
 
     </ol>
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-      
+
 
 
             </div>
@@ -54,7 +54,7 @@ Early Years Foundation
 
 
 
-          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peeakaboo </p>
+          <p class="govuk-body govuk-!-font-weight-bold">Case study: Sarah plays peekaboo </p>
 
           <p class="govuk-body">Childminder Chris is playing with 6 month old Sarah. Chris is covering a teddy with a blanket. When the Teddy is covered, Sarah immediately pulls off the blanket to find it and giggles.
  </p>
@@ -99,7 +99,7 @@ Early Years Foundation
             </fieldset>
           </div>
 
-       
+
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">
 

--- a/app/views/brain-development/test-intro.html
+++ b/app/views/brain-development/test-intro.html
@@ -36,7 +36,7 @@ Early Years Foundation
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-          
+
 
             </div>
 
@@ -49,7 +49,7 @@ Early Years Foundation
           <h1 class="govuk-heading-l">
             End of module quiz
           </h1>
-          <p class="govuk-body">This end of module quiz to revisit what you have learned and the impact on your practice.  is not aimed to provide a pass or fail.</p>
+          <p class="govuk-body">This end of module quiz is here to revisit what you have learned and the impact on your practice. It is not aimed to provide a pass or fail.</p>
 
           <h3 class="govuk-heading-s">Before you start</h3>
 
@@ -61,7 +61,7 @@ Early Years Foundation
 
 
 
-         
+
 
 
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4">

--- a/app/views/brain-development/topic-intro-existing.html
+++ b/app/views/brain-development/topic-intro-existing.html
@@ -23,7 +23,7 @@ Early Years Foundation
       </li>
 
     </ol>
-    
+
   </div>
   <strong class="govuk-tag govuk-tag--turquoise">
     Resuming
@@ -35,20 +35,20 @@ Early Years Foundation
     <div class="govuk-grid-row">
 
       <div class="govuk-grid-column-one-quarter">
-         
+
 
 
         </div>
 
-          
+
 
       <div class="govuk-grid-column-two-thirds">
-          
-        <span class="govuk-caption-l">Topic 3 of 13</span>
+
+        <span class="govuk-caption-l">Page 3 of 10</span>
         <h1 class="govuk-heading-l">
           Brain development before birth
         </h1>
-  
+
 
 <p class="govuk-body">Over the following pages we will identify and explain the expected patterns of brain and early language development and then consider the influences that may impact on a child’s brain development even before they are born.</p>
 

--- a/app/views/brain-development/topic-intro.html
+++ b/app/views/brain-development/topic-intro.html
@@ -31,19 +31,19 @@ Early Years Foundation
     <div class="govuk-grid-row">
 
       <div class="govuk-grid-column-one-quarter">
-         
+
 
 
         </div>
 
-          
+
 
       <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-l">Topic 3 of 13</span>
+        <span class="govuk-caption-l">Page 3 of 10</span>
         <h1 class="govuk-heading-l">
           Brain development before birth
         </h1>
-  
+
 
 <p class="govuk-body">Over the following pages we will identify and explain the expected patterns of brain and early language development and then consider the influences that may impact on a child’s brain development even before they are born.</p>
 


### PR DESCRIPTION
Should skip straight from piaget-current-research to relationships-emotions and then to recap without showing a question. Skipping question to save time in UR - already tested.